### PR TITLE
fix deprecated calling of static property on trait

### DIFF
--- a/src/Models/Customer.php
+++ b/src/Models/Customer.php
@@ -60,13 +60,13 @@ class Customer extends DearClient
             config('dear-database.models.contact_address') => [
                 'model' => config('dear-database.models.contact_address'),
                 'table' => 'contact_addresses',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Addresses'
             ],
             config('dear-database.models.contact') => [
                 'model' => config('dear-database.models.contact'),
                 'table' => 'contacts',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Contacts'
             ]
         ];

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -109,13 +109,13 @@ class Product extends Model
             config('dear-database.models.product_movement') => [
                 'model' => config('dear-database.models.product_movement'),
                 'table' => 'product_movements',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Movements',
             ],
             config('dear-database.models.attachment_line') => [
                 'model' => config('dear-database.models.attachment_line'),
                 'table' => 'attachment_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Attachments',
             ],
         ];

--- a/src/Models/Purchase.php
+++ b/src/Models/Purchase.php
@@ -112,13 +112,13 @@ class Purchase extends Model
             config('dear-database.models.attachment_line') => [
                 'model' => config('dear-database.models.attachment_line'),
                 'table' => 'attachment_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Attachments',
             ],
             config('dear-database.models.inventory_movement_line') => [
                 'model' => config('dear-database.models.inventory_movement_line'),
                 'table' => 'inventory_movement_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'InventoryMovements',
             ],
         ];

--- a/src/Models/PurchaseCreditNote.php
+++ b/src/Models/PurchaseCreditNote.php
@@ -50,25 +50,25 @@ class PurchaseCreditNote extends Model
             config('dear-database.models.purchase_invoice_line') => [
                 'model' => config('dear-database.models.purchase_invoice_line'),
                 'table' => 'purchase_invoice_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Lines',
             ],
             config('dear-database.models.purchase_invoice_additional_charge') => [
                 'model' => config('dear-database.models.purchase_invoice_additional_charge'),
                 'table' => 'purchase_invoice_additional_charges',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'AdditionalCharges',
             ],
             config('dear-database.models.purchase_payment_line') => [
                 'model' => config('dear-database.models.purchase_payment_line'),
                 'table' => 'purchase_payment_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Refunds',
             ],
             config('dear-database.models.purchase_unstock_line') => [
                 'model' => config('dear-database.models.purchase_unstock_line'),
                 'table' => 'purchase_unstock_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Unstock',
             ],
         ];

--- a/src/Models/PurchaseInvoice.php
+++ b/src/Models/PurchaseInvoice.php
@@ -54,19 +54,19 @@ class PurchaseInvoice extends Model
             config('dear-database.models.purchase_invoice_line') => [
                 'model' => config('dear-database.models.purchase_invoice_line'),
                 'table' => 'purchase_invoice_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Lines',
             ],
             config('dear-database.models.purchase_invoice_additional_charge') => [
                 'model' => config('dear-database.models.purchase_invoice_additional_charge'),
                 'table' => 'purchase_invoice_additional_charges',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'AdditionalCharges',
             ],
             config('dear-database.models.purchase_payment_line') => [
                 'model' => config('dear-database.models.purchase_payment_line'),
                 'table' => 'purchase_payment_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Payments',
             ],
         ];

--- a/src/Models/PurchaseManualJournal.php
+++ b/src/Models/PurchaseManualJournal.php
@@ -34,7 +34,7 @@ class PurchaseManualJournal extends Model
             config('dear-database.models.purchase_manual_journal_line') => [
                 'model' => config('dear-database.models.purchase_manual_journal_line'),
                 'table' => 'purchase_manual_journal_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Lines',
             ],
         ];

--- a/src/Models/PurchaseOrder.php
+++ b/src/Models/PurchaseOrder.php
@@ -38,19 +38,19 @@ class PurchaseOrder extends Model
             config('dear-database.models.purchase_order_line') => [
                 'model' => config('dear-database.models.purchase_order_line'),
                 'table' => 'purchase_order_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Lines',
             ],
             config('dear-database.models.purchase_additional_charge') => [
                 'model' => config('dear-database.models.purchase_additional_charge'),
                 'table' => 'purchase_additional_charges',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'AdditionalCharges',
             ],
             config('dear-database.models.purchase_payment_line') => [
                 'model' => config('dear-database.models.purchase_payment_line'),
                 'table' => 'purchase_payment_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Prepayments',
             ],
         ];

--- a/src/Models/PurchaseStock.php
+++ b/src/Models/PurchaseStock.php
@@ -34,7 +34,7 @@ class PurchaseStock extends Model
             config('dear-database.models.purchase_stock_line') => [
                 'model' => config('dear-database.models.purchase_stock_line'),
                 'table' => 'purchase_stock_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Lines',
             ],
         ];

--- a/src/Models/Sale.php
+++ b/src/Models/Sale.php
@@ -116,31 +116,31 @@ class Sale extends Model
             config('dear-database.models.sale_fulfilment') => [
                 'model' => config('dear-database.models.sale_fulfilment'),
                 'table' => 'sale_fulfilments',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Fulfilments',
             ],
             config('dear-database.models.sale_invoice') => [
                 'model' => config('dear-database.models.sale_invoice'),
                 'table' => 'sale_invoices',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Invoices',
             ],
             config('dear-database.models.sale_credit_note') => [
                 'model' => config('dear-database.models.sale_credit_note'),
                 'table' => 'sale_credit_notes',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'CreditNotes',
             ],
             config('dear-database.models.attachment_line') => [
                 'model' => config('dear-database.models.attachment_line'),
                 'table' => 'attachment_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Attachments',
             ],
             config('dear-database.models.inventory_movement_line') => [
                 'model' => config('dear-database.models.inventory_movement_line'),
                 'table' => 'inventory_movement_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'InventoryMovements',
             ],
         ];

--- a/src/Models/SaleCreditNote.php
+++ b/src/Models/SaleCreditNote.php
@@ -48,25 +48,25 @@ class SaleCreditNote extends Model
             config('dear-database.models.sale_invoice_line') => [
                 'model' => config('dear-database.models.sale_invoice_line'),
                 'table' => 'sale_invoice_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Lines',
             ],
             config('dear-database.models.sale_invoice_additional_charge') => [
                 'model' => config('dear-database.models.sale_invoice_additional_charge'),
                 'table' => 'sale_invoice_additional_charges',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'AdditionalCharges',
             ],
             config('dear-database.models.sale_payment_line') => [
                 'model' => config('dear-database.models.sale_payment_line'),
                 'table' => 'sale_payment_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Refunds',
             ],
             config('dear-database.models.sale_restock_line') => [
                 'model' => config('dear-database.models.sale_restock_line'),
                 'table' => 'sale_restock_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Restock',
             ],
         ];

--- a/src/Models/SaleFulfilmentPack.php
+++ b/src/Models/SaleFulfilmentPack.php
@@ -28,7 +28,7 @@ class SaleFulfilmentPack extends Model
             config('dear-database.models.sale_fulfilment_pack_line') => [
                 'model' => config('dear-database.models.sale_fulfilment_pack_line'),
                 'table' => 'sale_fulfilment_pack_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Lines',
             ],
         ];

--- a/src/Models/SaleFulfilmentPick.php
+++ b/src/Models/SaleFulfilmentPick.php
@@ -33,7 +33,7 @@ class SaleFulfilmentPick extends Model
             config('dear-database.models.sale_fulfilment_pick_line') => [
                 'model' => config('dear-database.models.sale_fulfilment_pick_line'),
                 'table' => 'sale_fulfilment_pick_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Lines',
             ],
         ];

--- a/src/Models/SaleFulfilmentShip.php
+++ b/src/Models/SaleFulfilmentShip.php
@@ -48,7 +48,7 @@ class SaleFulfilmentShip extends Model
             config('dear-database.models.sale_fulfilment_ship_line') => [
                 'model' => config('dear-database.models.sale_fulfilment_ship_line'),
                 'table' => 'sale_fulfilment_ship_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Lines',
             ],
         ];

--- a/src/Models/SaleInvoice.php
+++ b/src/Models/SaleInvoice.php
@@ -59,19 +59,19 @@ class SaleInvoice extends Model
             config('dear-database.models.sale_invoice_line') => [
                 'model' => config('dear-database.models.sale_invoice_line'),
                 'table' => 'sale_invoice_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Lines',
             ],
             config('dear-database.models.sale_invoice_additional_charge') => [
                 'model' => config('dear-database.models.sale_invoice_additional_charge'),
                 'table' => 'sale_invoice_additional_charges',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'AdditionalCharges',
             ],
             config('dear-database.models.sale_payment_line') => [
                 'model' => config('dear-database.models.sale_payment_line'),
                 'table' => 'sale_payment_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Payments',
             ],
         ];

--- a/src/Models/SaleManualJournal.php
+++ b/src/Models/SaleManualJournal.php
@@ -29,7 +29,7 @@ class SaleManualJournal extends Model
             config('dear-database.models.sale_manual_journal_line') => [
                 'model' => config('dear-database.models.sale_manual_journal_line'),
                 'table' => 'sale_manual_journal_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Lines',
             ],
         ];

--- a/src/Models/SaleOrder.php
+++ b/src/Models/SaleOrder.php
@@ -39,13 +39,13 @@ class SaleOrder extends Model
             config('dear-database.models.sale_order_line') => [
                 'model' => config('dear-database.models.sale_order_line'),
                 'table' => 'sale_order_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Lines',
             ],
             config('dear-database.models.sale_additional_charge') => [
                 'model' => config('dear-database.models.sale_additional_charge'),
                 'table' => 'sale_additional_charges',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'AdditionalCharges',
             ],
         ];

--- a/src/Models/SaleQuote.php
+++ b/src/Models/SaleQuote.php
@@ -38,19 +38,19 @@ class SaleQuote extends Model
             config('dear-database.models.sale_payment_line') => [
                 'model' => config('dear-database.models.sale_payment_line'),
                 'table' => 'sale_payment_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Prepayments',
             ],
             config('dear-database.models.sale_quote_line') => [
                 'model' => config('dear-database.models.sale_quote_line'),
                 'table' => 'sale_quote_lines',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Lines',
             ],
             config('dear-database.models.sale_additional_charge') => [
                 'model' => config('dear-database.models.sale_additional_charge'),
                 'table' => 'sale_additional_charges',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'AdditionalCharges',
             ],
         ];

--- a/src/Models/Supplier.php
+++ b/src/Models/Supplier.php
@@ -53,13 +53,13 @@ class Supplier extends DearClient
             config('dear-database.models.contact_address') => [
                 'model' => config('dear-database.models.contact_address'),
                 'table' => 'contact_addresses',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Addresses'
             ],
             config('dear-database.models.contact') => [
                 'model' => config('dear-database.models.contact'),
                 'table' => 'contacts',
-                'relationship_type' => DearModel::$MANY_TO_MANY,
+                'relationship_type' => self::$MANY_TO_MANY,
                 'dear_key' => 'Contacts'
             ]
         ];


### PR DESCRIPTION
## Proposed changes

_Description of the changes implemented by this PR, feel free to be as verbose as needed_

- fix deprecated calling of static property on trait
- https://wiki.php.net/rfc/deprecations_php_8_1#accessing_static_members_on_traits

## Types of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply, leave blank if none_

- [ ] Frontend
- [x] Backend
- [ ] Bugfix
- [ ] New feature
- [ ] Component of Major Release
- [ ] Project Management
- [ ] Quality of Life
- [ ] Test Improvements

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Local Cypress Tests Pass with my changes (`yarn cypress:run`)
- [ ] Lint and unit tests pass locally with my changes (`yarn lint && ./vendor/bin/phpunit`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Dependant PRs

_List Pull Requests below in format `#<ISSUE-NUMBER>`_
- ...

## Relevant Issues

_List Issues below in format `#<ISSUE-NUMBER> [Full|Partial]`_
- ...