### PR TITLE
fixing spelling of purchaseSupplier return type

### DIFF
--- a/src/Models/Purchase.php
+++ b/src/Models/Purchase.php
@@ -130,7 +130,7 @@ class Purchase extends Model
         return PurchaseFactory::new();
     }
 
-    public function purchaseSupplier(): hasOne
+    public function purchaseSupplier(): HasOne
     {
         return $this->hasOne(config('dear-database.models.supplier'), 'external_guid', 'supplier_guid');
     }


### PR DESCRIPTION
## Proposed changes

_Description of the changes implemented by this PR, feel free to be as verbose as needed_

Fixing spelling mistake on purchaseSupplier function return type from hasOne to HasOne
...

## Types of changes

What type of changes does your code introduce?
_Put an `x` in the boxes that apply, leave blank if none_

- [ ] Frontend
- [x] Backend
- [ ] Bugfix
- [ ] New feature
- [ ] Component of Major Release
- [ ] Project Management
- [ ] Quality of Life
- [ ] Test Improvements

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Local Cypress Tests Pass with my changes (`yarn cypress:run`)
- [ ] Lint and unit tests pass locally with my changes (`yarn lint && ./vendor/bin/phpunit`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Dependant PRs

_List Pull Requests below in format `#<ISSUE-NUMBER>`_
- ...

## Relevant Issues

_List Issues below in format `#<ISSUE-NUMBER> [Full|Partial]`_
- ...

## Description

_If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc._

